### PR TITLE
cleanup

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -4,11 +4,5 @@
       "source": "/(.*)",
       "destination": "/$1"
     }
-  ],
-  "routes": [
-    {
-      "src": "(.*)",
-      "dest": "/$1"
-    }
   ]
 } 


### PR DESCRIPTION
- removed the redundant routes section, as the rewrites configuration is already handling what you need, this was causing deployment errors with vercel